### PR TITLE
Renamed trusted collaborators to the standardised trusted committer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ If you are asked to 'Commit directly...' vs 'Create a new branch...'
 
 * Assure you select **'Create a new branch...'** and name the branch like this example: "pattern/project-management-time-pressures". 
 * This occurs when writing a new pattern via the web interface (section A above).
-* Only [Trusted Collaborators](/meta/trusted-collaborators.md) (TC's) are asked this; we are adding most contributors as TC's.
+* Only [Trusted Committers](/meta/trusted-committers.md) (TC's) are asked this; we are adding most contributors as TC's.
 
 
 ## Other Tips For Submissions
@@ -89,7 +89,7 @@ Below are the procedural steps in our Review process:
 3. Reviewers can now use the PR features to comment on the pattern.
 4. In most cases, we do two reviews, and the PR's labels should reflect `Do 2nd Review` etc.
 5. After reviews are complete, the reviewers or author should Revise and Finalize the pattern, eventually labeling it with  `Accepted`.
-6. Once a pattern is `Accepted` by the reviewers, one of the [Trusted Collaborators](/meta/trusted-collaborators.md) (most authors are by this point) can Merge the PR on Github. This places the .md file into the master branch / root directory.
+6. Once a pattern is `Accepted` by the reviewers, one of the [Trusted Committers](/meta/trusted-committers.md) (most authors are by this point) can Merge the PR on Github. This places the .md file into the master branch / root directory.
 
 ## Completed Patterns
 When completed patterns (reviewed and accepted) are ready to be published from this InnerSourcePatterns repo to a Gitbook (PDF), [see our separate Publishing instructions](/meta/publishing.md).

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The topics below cover information about how we define, operate, and upkeep this
 
 * [Pattern Template](meta/pattern-template.md) - Start a new pattern with a copy of this
 * [Pattern States](meta/pattern-states.md) - Definitions of the various states and review steps a pattern can be in
-* [Trusted Collaborators](meta/trusted-collaborators.md) - Who these people are, what elevated rights they get, and how you can become one
+* [Trusted Committers](meta/trusted-committers.md) - Who these people are, what elevated rights they get, and how you can become one
 * [Publishing](meta/publishing.md) - How we take completed, reviewed, proven patterns and publish them toward an online book
 * [Markdown Info](meta/markdown-info.md) - Markdown is the ascii text format our patterns are written in; this document briefly defines how we use it
 * [Contributing](CONTRIBUTING.md) - How to interact with our group, create your own patterns, or take part in our review-process; Github / Web centric instructions

--- a/meta/trusted-committers.md
+++ b/meta/trusted-committers.md
@@ -1,6 +1,6 @@
-# Trusted Collaborators
+# Trusted Committers
 
-Trusted collaborators/contributors/committers (TC's) are those members of our community who we have explicitly added to our Github repository. These people have elevated rights, allowing them to send in changes directly to branches and to accept Pull Requests.
+Trusted committers/collaborators/contributors (TC's) are those members of our community who we have explicitly added to our Github repository. These people have elevated rights, allowing them to send in changes directly to branches and to accept Pull Requests.
 
 We ask that TC's still adhere to the Pull-Request mechanism, unless they are making changes to documentation where it is not realistic that anyone will review, or if there are easy typos/grammar fixes.
 
@@ -12,7 +12,7 @@ Adding people off-the-bat encourages more contributions, displays trust, allows 
 If you want to become a Collaborator, @ mention one of the [Admins](#admins) in an Issue.
 
 ## Admins
-There are currently a handful of Github Admins for this repository. They hold the ability to add collaborators and modify the repositories nuclear options (delete, rename, etc).
+There are currently a handful of Github Admins for this repository. They hold the ability to add Committers and modify the repositories nuclear options (delete, rename, etc).
 
 * @nyeates - ask me first
 * @gruetter

--- a/meta/trusted-committers.md
+++ b/meta/trusted-committers.md
@@ -2,6 +2,8 @@
 
 Trusted committers/collaborators/contributors (TC's) are those members of our community who we have explicitly added to our Github repository. These people have elevated rights, allowing them to send in changes directly to branches and to accept Pull Requests.
 
+GitHub refers to these accounts as [collaborators](https://help.github.com/en/articles/adding-outside-collaborators-to-repositories-in-your-organization).
+
 We ask that TC's still adhere to the Pull-Request mechanism, unless they are making changes to documentation where it is not realistic that anyone will review, or if there are easy typos/grammar fixes.
 
 ## Who we add

--- a/project-roles/trusted-committer.md
+++ b/project-roles/trusted-committer.md
@@ -163,5 +163,5 @@ Published internally at Nike; drafted via pull-request in June of 2018.
 [Loren Sanz]: https://github.com/mrsanz
 [Jeremy Hicks]: https://github.com/greatestusername
 [Noah Cawley]: https://github.com/utanapishtim
-[praise]: https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/praise-participants.md
+[praise]: /praise-participants.md
 [Fernando Freire]: https://github.com/dogonthehorizon


### PR DESCRIPTION
The community has standardised the terminology and definition of [Trusted Committer](project-roles/trusted-committer.md). As such, we should probably use the same nomenclature within our own repositories.